### PR TITLE
Opacity from beamdata

### DIFF
--- a/src/ess/polarization/base.py
+++ b/src/ess/polarization/base.py
@@ -314,7 +314,7 @@ def he3_opacity_from_beam_data(
     :py:func:`he3_opacity_from_cell_params`.
     """
     raise NotImplementedError()
-    return He3Opacity[Cell]()
+    return He3Opacity[Cell](1)
 
 
 def he3_polarization(

--- a/src/ess/polarization/base.py
+++ b/src/ess/polarization/base.py
@@ -315,7 +315,7 @@ def he3_opacity_from_beam_data(
     """
     """
     direct_beam_cell, and direct_beam = data arrays with wavelength information
-    --> the result of eq. 1 down would give O for these different wavelength. 
+    --> the result of eq. 1 down would give O for these different wavelength.
     --> that can be either averaged/concatenated
     --> or O is fit to eq. 2
    eq1: He3Opacity[Cell] = -sc.log[direct_beam_cell/direct_beam*1/transmission_empty_glass]
@@ -324,7 +324,9 @@ def he3_opacity_from_beam_data(
     """
 
     raise NotImplementedError()
-    return He3Opacity[Cell](-sc.log[direct_beam_cell/direct_beam*1/transmission_empty_glass])
+    return He3Opacity[Cell](
+        -sc.log[direct_beam_cell / direct_beam * 1 / transmission_empty_glass]
+    )
 
 
 def he3_polarization(

--- a/src/ess/polarization/base.py
+++ b/src/ess/polarization/base.py
@@ -307,6 +307,13 @@ def he3_opacity_from_beam_data(
     direct_beam: DirectBeamNoCell,
     direct_beam_cell: He3DirectBeam[Cell, Depolarized],
 ) -> He3Opacity[Cell]:
+    
+    def Intensity_direct_beam_cell(time, opacity_cell):
+        return direct_beam*transmission_empty_glass*sc.exp(-opacity_cell)
+    
+    popt, pcov = sc.curve_fit(['time'], reduce_dims = ['wavelength'], Intensity_direct_beam_cell, direct_beam_cell)
+    # Q: correct to use 'time' on x-axis?
+    # expected output: popt = opacity = single parameter for each cell, wavelength independent
     """
     Opacity for a given cell, based on direct beam data.
 
@@ -340,9 +347,7 @@ def he3_opacity_from_beam_data(
     """
 
     raise NotImplementedError()
-    return He3Opacity[Cell](
-        -sc.log[direct_beam_cell / direct_beam * 1 / transmission_empty_glass]
-    )
+    return He3Opacity[Cell](popt)
 
 
 def he3_polarization(

--- a/src/ess/polarization/base.py
+++ b/src/ess/polarization/base.py
@@ -313,8 +313,18 @@ def he3_opacity_from_beam_data(
     Note that this can alternatively be computed from cell parameters, see
     :py:func:`he3_opacity_from_cell_params`.
     """
+    """
+    direct_beam_cell, and direct_beam = data arrays with wavelength information
+    --> the result of eq. 1 down would give O for these different wavelength. 
+    --> that can be either averaged/concatenated
+    --> or O is fit to eq. 2
+   eq1: He3Opacity[Cell] = -sc.log[direct_beam_cell/direct_beam*1/transmission_empty_glass]
+   eq2: direct_beam_cell = direct_beam*transmission_empty_glass*sc.exp(-He3Opacity[Cell])
+   --> But : that might still give different values of O for different wavelength? As Simon how to fit to all data simulatneously
+    """
+
     raise NotImplementedError()
-    return He3Opacity[Cell](1)
+    return He3Opacity[Cell](-sc.log[direct_beam_cell/direct_beam*1/transmission_empty_glass])
 
 
 def he3_polarization(

--- a/src/ess/polarization/base.py
+++ b/src/ess/polarization/base.py
@@ -321,31 +321,9 @@ def he3_opacity_from_beam_data(
     :py:func:`he3_opacity_from_cell_params`.
     """
     """
-    direct_beam_cell, and direct_beam = data arrays with wavelength information
-    --> the result of eq. 1 down would give O for these different wavelength.
-    --> that can be either averaged/concatenated
-    --> or O is fit to eq. 2
-   eq1: He3Opacity[Cell] = -sc.log[direct_beam_cell/direct_beam*1/transmission_empty_glass]
-   eq2: Intensity_direct_beam_cell = direct_beam*transmission_empty_glass*sc.exp(-He3Opacity[Cell])
-
-   --> But : that might still give different values of O for different wavelength? As Simon how to fit to all data simulatneously
-       
-       popt, pcov = sc.curve_fit(['time'], reduce_dims=('wavelength'), Intensity_direct_beam_cell, direct_beam_cell)
-       
-    # from scipp: curve_fit(['x'], func, da, p0 = {'b': 1.0 / sc.Unit('m')})
-    # Do this at 1AA, or just for all wavelength?
-    # Would it be better to (i) take a mean popt for all wavelength, or (ii) compute it just for one wavelength, or (iii) have single parameters for all wavelength?
-    # Maybe can use reduce_dims=['wavelength'] of the scipp.curve_fit (see example)
-
-    reduce_dims (Sequence[str], default: ()) 
-    --> Additional dimensions to aggregate while fitting. 
-    If a dimension is not in reduce_dims, or in the dimensions of the coords used in the fit, 
-    then the values of the optimal parameters will depend on that dimension. 
-    ne fit will be performed for every slice, and the data arrays in the output will have the dimension in their dims. 
-    If a dimension is passed to reduce_dims all data in that dimension is instead aggregated in a single fit 
-    and the dimension will not be present in the output.
+    Discussion with Hal:
+    We can compute the same opacity for all wavelength by fitting a value that fits to all measurements. - This is done by "reduce_dims"?
     """
-
     raise NotImplementedError()
     return He3Opacity[Cell](popt)
 

--- a/src/ess/polarization/base.py
+++ b/src/ess/polarization/base.py
@@ -319,8 +319,24 @@ def he3_opacity_from_beam_data(
     --> that can be either averaged/concatenated
     --> or O is fit to eq. 2
    eq1: He3Opacity[Cell] = -sc.log[direct_beam_cell/direct_beam*1/transmission_empty_glass]
-   eq2: direct_beam_cell = direct_beam*transmission_empty_glass*sc.exp(-He3Opacity[Cell])
+   eq2: Intensity_direct_beam_cell = direct_beam*transmission_empty_glass*sc.exp(-He3Opacity[Cell])
+
    --> But : that might still give different values of O for different wavelength? As Simon how to fit to all data simulatneously
+       
+       popt, pcov = sc.curve_fit(['time'], reduce_dims=('wavelength'), Intensity_direct_beam_cell, direct_beam_cell)
+       
+    # from scipp: curve_fit(['x'], func, da, p0 = {'b': 1.0 / sc.Unit('m')})
+    # Do this at 1AA, or just for all wavelength?
+    # Would it be better to (i) take a mean popt for all wavelength, or (ii) compute it just for one wavelength, or (iii) have single parameters for all wavelength?
+    # Maybe can use reduce_dims=['wavelength'] of the scipp.curve_fit (see example)
+
+    reduce_dims (Sequence[str], default: ()) 
+    --> Additional dimensions to aggregate while fitting. 
+    If a dimension is not in reduce_dims, or in the dimensions of the coords used in the fit, 
+    then the values of the optimal parameters will depend on that dimension. 
+    ne fit will be performed for every slice, and the data arrays in the output will have the dimension in their dims. 
+    If a dimension is passed to reduce_dims all data in that dimension is instead aggregated in a single fit 
+    and the dimension will not be present in the output.
     """
 
     raise NotImplementedError()

--- a/src/ess/polarization/base.py
+++ b/src/ess/polarization/base.py
@@ -303,16 +303,17 @@ def he3_opacity_from_cell_params(
 
 
 def he3_opacity_from_beam_data(
-    transmission_empty_glass: He3TransmissionEmptyGlass[Cell],
-    direct_beam: DirectBeamNoCell,
-    direct_beam_cell: He3DirectBeam[Cell, Depolarized],
+    Tg: He3TransmissionEmptyGlass[Cell],
+    I0: DirectBeamNoCell,
+    Idepol: He3DirectBeam[Cell, Depolarized],
 ) -> He3Opacity[Cell]:
     
-    def Intensity_direct_beam_cell(time, opacity_cell):
-        return direct_beam*transmission_empty_glass*sc.exp(-opacity_cell)
+    def Intensity_direct_beam_cell(wavelength, O_0):
+        return Tg*sc.exp(-O_0*wavelength)
     
-    popt, pcov = sc.curve_fit(['time'], reduce_dims = ['wavelength'], Intensity_direct_beam_cell, direct_beam_cell)
-    # Q: correct to use 'time' on x-axis?
+    I_div = Idepol/I0
+    popt, pcov = sc.curve_fit(['wavelength'], Intensity_direct_beam_cell, I_div)  
+
     # expected output: popt = opacity = single parameter for each cell, wavelength independent
     """
     Opacity for a given cell, based on direct beam data.


### PR DESCRIPTION
We need the opacity as input for the 3He-polarization. Here the opacity is fit to the equation given by beamdata measurements. Using reduce_dims[wavelength] should (correct?) fit one value of opacity to all I(lambda).