### PR TITLE
Detailed specifications for SANS options at DREAM

### DIFF
--- a/docs/user-guide/DREAM-SANS-methodology.ipynb
+++ b/docs/user-guide/DREAM-SANS-methodology.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "788a4fce-63dc-4c23-8d2a-e9a05db0fdf7",
+   "metadata": {},
+   "source": [
+    "# DREAM-SANS methodology\n",
+    "\n",
+    "The general data reduction scheme presented in \"SANS Polarization Analysis Methodology\" will be adapted for the SANS option at the DREAM instrument at the ESS. Following considerations have to be changed with respect to the general methodology:\n",
+    "\n",
+    "### Polarizer:<br>\n",
+    "The DREAM-polarizer is a movable in-situ SEOP <sup>3</sup>He-cell of which the neutron polarization $P^{^3\\textup{He, p}}$ has to be pre-characterized in commissioning measurements and inserted into this workflow. Its wavelength-independent opacity $O^{\\textup{0, p}}$, empty-glass transmission $T^{\\textup{g, p}}$, pre-factor of nuclear polarization $C^{\\textup{p}}$, and its time-decay constant $T^{\\textup{1, p}}$ can be measured once in every commissioning time via Workflow 2 of \"SANS Polarization Analysis Methodology\". The resulting $P^{^3\\textup{He, p}}$ can be inserted into the workflow as constant parameter. To account for sudden fluctuations of $P^{^3\\textup{He, p}}$, which can occur due to changes in pressure or the like, the beam intensity after the polarizer has to be continuously recorded as function of time. Sudden fluctuations in intensity above a pre-defined difference in time must pop out an error message \"Critical intensity fluctuations detected in polarizer-monitor. Re-measure $P^{^3\\textup{He, p}}$!\".<br>\n",
+    "Note: Workflow 1 of \"SANS Polarization Analysis Methodology\" cannot be used for this polarizer. \n",
+    "\n",
+    "### Analyzer:<br>\n",
+    "In the current scope, DREAM will be equipped with 3 different SANS analyzers: (i) an ex-situ SEOP <sup>3</sup>He-cell, (ii) an in-situ SEOP <sup>3</sup>He-cell, and (iii) a SANS-window being part of a wide angle MEOP based <sup>3</sup>He-cell.\n",
+    "\n",
+    "(i)  The ex-situ SEOP <sup>3</sup>He-cell is a movable, time-dependent cell and has to be treated as described in \"SANS Polarization Analysis Methodology\".<br>\n",
+    "(ii)  The in-situ SEOP <sup>3</sup>He-cell is a movable, non-time-dependent cell and has to be treated as described above for the DREAM polarizer.<br>\n",
+    "(iii)  The ex-situ MEOP wide angle <sup>3</sup>He-cell with a small SANS window is a rotatable, time-dependent cell and has to be treated as the analyzer described in \"DREAM-diffraction methodology\".\n",
+    "\n",
+    "### Monitors:<br>\n",
+    "For an optimal SANS data-reduction, three monitors would be ideal: (i) an incident beam monitor $M_{\\textup{in}}$ before the polarizer, (ii) a monitor after the polarizer $M_{\\textup{p}}$, and (iii) a monitor after the analyzer $M_{\\textup{a}}$ (alternatively on the main detector if the direct beam can be recorded). At DREAM, only two monitors will be inserted: $M_{\\textup{p}}$ and $M_{\\textup{a}}$. In general, the total beam intensity is corrected by $M_{\\textup{in}}$. Due to the time-independence of $P^{^3\\textup{He, p}}$, the beam intensity of $M_{\\textup{p}}$ can be used instead.\n",
+    "\n",
+    "### Sample-movements:<br>\n",
+    "At DREAM, the samples cannot be moved in and out of beam with a motor and hence changes in sample position have to be done by hand. This is feasible sometimes during the workflow, but not in a regular manner (especially overnight). We will open two options for the users:\n",
+    "\n",
+    "(a) to use the workflow as-is with the sample in beam, and recording the direct-beam for polarization data reduction as described above, but in transmission through the sample. This will be an option for non-time-dependent, and non-(or weak-)spin-dependent scatterers, but not a good option for strong-spin-dependent scatterers like hydrogen. In this case, the correction for transmission through the sample has to be taken out of the \"unpolarized\" data reduction workflow (which is being performed before the polarizion data reduction).\n",
+    "\n",
+    "(b) for strong-spin-dependent scatterers, the sample will have too much impact on the data correction procedure and has to be moved out of beam for the direct beam measurements for polarization correction. The user has to do this by hand frequently throughout the beamtime. No changes to above polarization correction are needed.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Different workflows for different insruments / specifications will have to be created following the current sans-polarization-analysis-methodology. There will be workflows according to DREAM-SANS, SKADI-SANS, and DREAM-Diffraction - all having slightly different polarizers/analyzers & monitors, and hence slightly different time-dependencies etc.

Here I add the detailed specifications for SANS options at DREAM.