### PR TITLE
Implement polarization correction

### DIFF
--- a/docs/user-guide/workflow.ipynb
+++ b/docs/user-guide/workflow.ipynb
@@ -87,7 +87,12 @@
    "outputs": [],
    "source": [
     "workflow = pol.he3.He3CellWorkflow()\n",
-    "results = (pol.PolarizationCorrectedData,)\n",
+    "results = (\n",
+    "    pol.PolarizationCorrectedData[pol.Up, pol.Up],\n",
+    "    pol.PolarizationCorrectedData[pol.Up, pol.Down],\n",
+    "    pol.PolarizationCorrectedData[pol.Down, pol.Up],\n",
+    "    pol.PolarizationCorrectedData[pol.Down, pol.Down],\n",
+    ")\n",
     "workflow.visualize(results, graph_attr={\"rankdir\": \"LR\"})"
    ]
   },
@@ -105,7 +110,6 @@
    "outputs": [],
    "source": [
     "workflow = pol.he3.He3CellWorkflow(in_situ=False)\n",
-    "results = (pol.PolarizationCorrectedData,)\n",
     "workflow.visualize(results, graph_attr={\"rankdir\": \"LR\"})"
    ]
   },
@@ -127,7 +131,7 @@
     "from ess.polarization.correction import CorrectionWorkflow\n",
     "\n",
     "workflow = CorrectionWorkflow()\n",
-    "workflow.visualize(pol.PolarizationCorrectedData, graph_attr={\"rankdir\": \"LR\"})"
+    "workflow.visualize(results, graph_attr={\"rankdir\": \"LR\"})"
    ]
   }
  ],

--- a/docs/user-guide/workflow.ipynb
+++ b/docs/user-guide/workflow.ipynb
@@ -67,7 +67,7 @@
    "source": [
     "workflow = pol.he3.He3CellWorkflow()\n",
     "workflow.visualize(\n",
-    "    pol.He3TransmissionFunction[pol.Polarizer], graph_attr={'rankdir': 'LR'}\n",
+    "    pol.He3TransmissionFunction[pol.Polarizer], graph_attr={\"rankdir\": \"LR\"}\n",
     ")"
    ]
   },
@@ -87,8 +87,8 @@
    "outputs": [],
    "source": [
     "workflow = pol.he3.He3CellWorkflow()\n",
-    "results = (pol.PolarizationCorrectedSampleData,)\n",
-    "workflow.visualize(results, graph_attr={'rankdir': 'LR'})"
+    "results = (pol.PolarizationCorrectedData,)\n",
+    "workflow.visualize(results, graph_attr={\"rankdir\": \"LR\"})"
    ]
   },
   {
@@ -105,8 +105,29 @@
    "outputs": [],
    "source": [
     "workflow = pol.he3.He3CellWorkflow(in_situ=False)\n",
-    "results = (pol.PolarizationCorrectedSampleData,)\n",
-    "workflow.visualize(results, graph_attr={'rankdir': 'LR'})"
+    "results = (pol.PolarizationCorrectedData,)\n",
+    "workflow.visualize(results, graph_attr={\"rankdir\": \"LR\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Correction workflow\n",
+    "\n",
+    "The correction worklow on its own looks as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ess.polarization.correction import CorrectionWorkflow\n",
+    "\n",
+    "workflow = CorrectionWorkflow()\n",
+    "workflow.visualize(pol.PolarizationCorrectedData, graph_attr={\"rankdir\": \"LR\"})"
    ]
   }
  ],

--- a/src/ess/polarization/__init__.py
+++ b/src/ess/polarization/__init__.py
@@ -30,8 +30,6 @@ from .base import (
 from .base import providers as base_providers
 from .base import run_reduction_workflow
 from .he3 import (
-    Analyzer,
-    Cell,
     Depolarized,
     DirectBeamBackgroundQRange,
     DirectBeamNoCell,
@@ -46,8 +44,6 @@ from .he3 import (
     He3TransmissionEmptyGlass,
     He3TransmissionFunction,
     Polarized,
-    Polarizer,
-    correct_sample_data_for_polarization,
     direct_beam,
     direct_beam_with_cell,
     get_he3_transmission_from_fit_to_direct_beam,
@@ -57,8 +53,11 @@ from .he3 import (
 )
 from .he3 import providers as he3_providers
 from .types import (
+    Analyzer,
     Down,
-    PolarizationCorrectedSampleData,
+    PolarizationCorrectedData,
+    Polarizer,
+    PolarizingElement,
     ReducedSampleDataBySpinChannel,
     Up,
 )
@@ -67,7 +66,7 @@ providers = base_providers + he3_providers
 
 __all__ = [
     "Analyzer",
-    "Cell",
+    "PolarizingElement",
     "CellInBeamLog",
     "CellSpinLog",
     "correct_sample_data_for_polarization",
@@ -99,7 +98,7 @@ __all__ = [
     "He3PolarizationFunction",
     "He3TransmissionEmptyGlass",
     "He3TransmissionFunction",
-    "PolarizationCorrectedSampleData",
+    "PolarizationCorrectedData",
     "Polarized",
     "Polarizer",
     "providers",

--- a/src/ess/polarization/__init__.py
+++ b/src/ess/polarization/__init__.py
@@ -69,7 +69,6 @@ __all__ = [
     "PolarizingElement",
     "CellInBeamLog",
     "CellSpinLog",
-    "correct_sample_data_for_polarization",
     "Depolarized",
     "determine_run_section",
     "direct_beam",

--- a/src/ess/polarization/base.py
+++ b/src/ess/polarization/base.py
@@ -6,15 +6,15 @@ import numpy as np
 import sciline as sl
 import scipp as sc
 
-from .he3 import (
+from .he3 import Polarized, ReducedDirectBeamData, ReducedDirectBeamDataNoCell
+from .types import (
     Analyzer,
-    Cell,
-    Polarized,
+    Down,
     Polarizer,
-    ReducedDirectBeamData,
-    ReducedDirectBeamDataNoCell,
+    PolarizingElement,
+    ReducedSampleDataBySpinChannel,
+    Up,
 )
-from .types import Down, ReducedSampleDataBySpinChannel, Up
 
 spin_up = sc.scalar(1, dtype='int64', unit=None)
 spin_down = sc.scalar(-1, dtype='int64', unit=None)
@@ -26,11 +26,11 @@ SampleInBeamLog = NewType('SampleInBeamLog', sc.DataArray)
 """Whether the sample is in the beam as a time series."""
 
 
-class CellInBeamLog(sl.Scope[Cell, sc.DataArray], sc.DataArray):
+class CellInBeamLog(sl.Scope[PolarizingElement, sc.DataArray], sc.DataArray):
     """Whether a given cell is in the beam as a time series."""
 
 
-class CellSpinLog(sl.Scope[Cell, sc.DataArray], sc.DataArray):
+class CellSpinLog(sl.Scope[PolarizingElement, sc.DataArray], sc.DataArray):
     """Spin state of a given cell, as a time series."""
 
 

--- a/src/ess/polarization/correction.py
+++ b/src/ess/polarization/correction.py
@@ -145,9 +145,6 @@ def compute_polarization_corrected_data(
     channel: ReducedSampleDataBySpinChannel[PolarizerSpin, AnalyzerSpin],
     polarization_correction: PolarizationCorrection[PolarizerSpin, AnalyzerSpin],
 ) -> PolarizationCorrectedData[PolarizerSpin, AnalyzerSpin]:
-    # We combine into Datasets so we can share coordinates when concatenating later
-    # TODO I think Scipp does not actually does this, it has a naive impl.
-    # Also, keep in mind that we are in general Q-binned, i.e., concat bins!
     # TODO Would like to use inplace ops, but modifying input is dodgy. Maybe combine
     # into a single function?
     return PolarizationCorrectedData(

--- a/src/ess/polarization/correction.py
+++ b/src/ess/polarization/correction.py
@@ -33,8 +33,6 @@ def correct_for_polarizing_element(
     t_minus_down = -transmission_function.apply(down, 'minus')
     up = up / (t_plus_up**2 - t_minus_up**2)
     down = down / (t_plus_down**2 - t_minus_down**2)
-    # TODO This inplace op might not work since we need additional coords from RHS,
-    # such as Q
     t_plus_up *= up
     t_minus_up *= up
     t_plus_down *= down
@@ -54,9 +52,11 @@ def correct_for_analyzer(
     transmission: TransmissionFunction[Analyzer],
 ) -> AnalyzerCorrectedData[PolarizerSpin]:
     part1, part2 = correct_for_polarizing_element(
-        analyzer_up, analyzer_down, transmission
+        analyzer_up, analyzer_down, transmission, prefix='analyzer_'
     )
-    return AnalyzerCorrectedData(**sc.concat([part1, part2], analyzer_up.dim))
+    return AnalyzerCorrectedData[PolarizerSpin](
+        **sc.concat([part1, part2], analyzer_up.dim)
+    )
 
 
 def correct_for_polarizer(

--- a/src/ess/polarization/correction.py
+++ b/src/ess/polarization/correction.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 import sciline
+import scipp as sc
 
 from .types import (
     Analyzer,
@@ -48,12 +49,11 @@ def compute_polarizing_element_correction(
     """
     t_plus = transmission.apply(channel, 'plus')
     t_minus = transmission.apply(channel, 'minus')
-    print(f'{t_plus=} {t_minus=}')
     t_minus *= -1
     denom = t_plus**2 - t_minus**2
-    print(f'{denom=}')
-    t_plus /= denom
-    t_minus /= denom
+    sc.reciprocal(denom, out=denom)
+    t_plus *= denom
+    t_minus *= denom
     return PolarizingElementCorrection[PolarizerSpin, AnalyzerSpin, PolarizingElement](
         diag=t_plus, off_diag=t_minus
     )

--- a/src/ess/polarization/correction.py
+++ b/src/ess/polarization/correction.py
@@ -1,107 +1,30 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-from dataclasses import dataclass
-
 import sciline
 import scipp as sc
 
 from .types import (
     Analyzer,
-    AnalyzerCorrectedData,
     AnalyzerSpin,
-    Down,
     PolarizationCorrectedData,
+    PolarizationCorrection,
     Polarizer,
     PolarizerSpin,
     PolarizingElement,
     PolarizingElementCorrection,
     ReducedSampleDataBySpinChannel,
     TransmissionFunction,
-    Up,
 )
-
-
-@dataclass
-class CorrectionComponents:
-    diag: sc.DataArray
-    off_diag: sc.DataArray
-
-
-def compute_correction_from_component(
-    channel: sc.DataArray,
-    transmission: TransmissionFunction[PolarizingElement],
-) -> CorrectionComponents:
-    t_plus = transmission.apply(channel, 'plus')
-    t_minus = -transmission.apply(channel, 'minus')
-    base = channel / (t_plus**2 - t_minus**2)
-    t_plus *= base
-    t_minus *= base
-    return CorrectionComponents(diag=t_plus, off_diag=t_minus)
-
-
-def correct_for_polarizing_element(
-    up: sc.DataArray,
-    down: sc.DataArray,
-    transmission_function: TransmissionFunction[PolarizingElement],
-    prefix: str = '',
-) -> tuple[sc.Dataset, sc.Dataset]:
-    """
-    denom = Tplus**2 - Tminus**2
-    mat = [[Tplus, -Tminus], [-Tminus, Tplus]]
-    """
-    components = compute_correction_from_component(up, transmission_function)
-    t_plus_up = components.diag
-    t_minus_up = components.off_diag
-    components = compute_correction_from_component(down, transmission_function)
-    t_plus_down = components.diag
-    t_minus_down = components.off_diag
-    # We combine into Datasets so we can share coordinates when concatenating later
-    # TODO I think Scipp does not actually does this, it has a naive impl.
-    # Also, keep in mind that we are in general Q-binned, i.e., concat bins!
-    return (
-        sc.Dataset({f'{prefix}up': t_plus_up, f'{prefix}down': t_minus_up}),
-        sc.Dataset({f'{prefix}up': t_minus_down, f'{prefix}down': t_plus_down}),
-    )
-
-
-def correct_for_analyzer(
-    analyzer_up: ReducedSampleDataBySpinChannel[PolarizerSpin, Up],
-    analyzer_down: ReducedSampleDataBySpinChannel[PolarizerSpin, Down],
-    transmission: TransmissionFunction[Analyzer],
-) -> AnalyzerCorrectedData[PolarizerSpin]:
-    part1, part2 = correct_for_polarizing_element(
-        analyzer_up, analyzer_down, transmission, prefix='analyzer_'
-    )
-    return AnalyzerCorrectedData[PolarizerSpin](
-        **sc.concat([part1, part2], analyzer_up.dim)
-    )
-
-
-def correct_for_polarizer(
-    polarizer_up: AnalyzerCorrectedData[Up],
-    polarizer_down: AnalyzerCorrectedData[Down],
-    transmission: TransmissionFunction[Polarizer],
-) -> PolarizationCorrectedData:
-    up_part1, up_part2 = correct_for_polarizing_element(
-        polarizer_up.analyzer_up, polarizer_down.analyzer_up, transmission, prefix='up'
-    )
-    down_part1, down_part2 = correct_for_polarizing_element(
-        polarizer_up.analyzer_down,
-        polarizer_down.analyzer_down,
-        transmission,
-        prefix='down',
-    )
-    part1 = sc.Dataset(**up_part1, **down_part1)
-    part2 = sc.Dataset(**up_part2, **down_part2)
-    return PolarizationCorrectedData(
-        **sc.concat([part1, part2], polarizer_up.analyzer_up.dim)
-    )
 
 
 def compute_polarizing_element_correction(
     channel: ReducedSampleDataBySpinChannel[PolarizerSpin, AnalyzerSpin],
     transmission: TransmissionFunction[PolarizingElement],
 ) -> PolarizingElementCorrection[PolarizerSpin, AnalyzerSpin, PolarizingElement]:
+    """
+    denom = Tplus**2 - Tminus**2
+    mat = [[Tplus, -Tminus], [-Tminus, Tplus]]
+    """
     t_plus = transmission.apply(channel, 'plus')
     t_minus = transmission.apply(channel, 'minus')
     t_minus *= -1
@@ -114,5 +37,40 @@ def compute_polarizing_element_correction(
     )
 
 
+def compute_polarization_correction(
+    analyzer: PolarizingElementCorrection[PolarizerSpin, AnalyzerSpin, Analyzer],
+    polarizer: PolarizingElementCorrection[PolarizerSpin, AnalyzerSpin, Polarizer],
+) -> PolarizationCorrection[PolarizerSpin, AnalyzerSpin]:
+    return PolarizationCorrection[PolarizerSpin, AnalyzerSpin](
+        upup=polarizer.diag * analyzer.diag,
+        updown=polarizer.diag * analyzer.off_diag,
+        downup=polarizer.off_diag * analyzer.diag,
+        downdown=polarizer.off_diag * analyzer.off_diag,
+    )
+
+
+def compute_polarization_corrected_data(
+    channel: ReducedSampleDataBySpinChannel[PolarizerSpin, AnalyzerSpin],
+    polarization_correction: PolarizationCorrection[PolarizerSpin, AnalyzerSpin],
+) -> PolarizationCorrectedData[PolarizerSpin, AnalyzerSpin]:
+    # We combine into Datasets so we can share coordinates when concatenating later
+    # TODO I think Scipp does not actually does this, it has a naive impl.
+    # Also, keep in mind that we are in general Q-binned, i.e., concat bins!
+    # TODO Would like to use inplace ops, but modifying input is dodgy. Maybe combine
+    # into a single function?
+    return PolarizationCorrectedData(
+        upup=channel * polarization_correction.upup,
+        updown=channel * polarization_correction.updown,
+        downup=channel * polarization_correction.downup,
+        downdown=channel * polarization_correction.downdown,
+    )
+
+
 def CorrectionWorkflow() -> sciline.Pipeline:
-    return sciline.Pipeline((correct_for_analyzer, correct_for_polarizer))
+    return sciline.Pipeline(
+        (
+            compute_polarizing_element_correction,
+            compute_polarization_correction,
+            compute_polarization_corrected_data,
+        )
+    )

--- a/src/ess/polarization/correction.py
+++ b/src/ess/polarization/correction.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+import sciline
+import scipp as sc
+
+from .types import (
+    Analyzer,
+    AnalyzerCorrectedData,
+    Down,
+    PolarizationCorrectedData,
+    Polarizer,
+    PolarizerSpin,
+    PolarizingElement,
+    ReducedSampleDataBySpinChannel,
+    TransmissionFunction,
+    Up,
+)
+
+
+def correct_for_polarizing_element(
+    up: sc.DataArray,
+    down: sc.DataArray,
+    transmission_function: TransmissionFunction[PolarizingElement],
+) -> tuple[sc.DataArray, sc.DataArray]:
+    """
+    denom = Tplus**2 - Tminus**2
+    mat = [[Tplus, -Tminus], [-Tminus, Tplus]]
+    """
+    t_plus_up = transmission_function.apply(up, 'plus')
+    t_minus_up = -transmission_function.apply(up, 'minus')
+    t_plus_down = transmission_function.apply(down, 'plus')
+    t_minus_down = -transmission_function.apply(down, 'minus')
+    up = up / (t_plus_up**2 - t_minus_up**2)
+    down = down / (t_plus_down**2 - t_minus_down**2)
+    t_plus_up *= up
+    t_minus_up *= up
+    t_plus_down *= down
+    t_minus_down *= down
+    out_up = sc.concat([t_plus_up, t_minus_down], up.dim)
+    out_down = sc.concat([t_minus_up, t_plus_down], down.dim)
+    return out_up, out_down
+
+
+def correct_for_analyzer(
+    up: ReducedSampleDataBySpinChannel[PolarizerSpin, Up],
+    down: ReducedSampleDataBySpinChannel[PolarizerSpin, Down],
+    transmission: TransmissionFunction[Analyzer],
+) -> AnalyzerCorrectedData[PolarizerSpin]:
+    up, down = correct_for_polarizing_element(up, down, transmission)
+    return AnalyzerCorrectedData(up=up, down=down)
+
+
+def correct_for_polarizer(
+    up: AnalyzerCorrectedData[Up],
+    down: AnalyzerCorrectedData[Down],
+    transmission: TransmissionFunction[Polarizer],
+) -> PolarizationCorrectedData:
+    upup, downup = correct_for_polarizing_element(up.up, down.up, transmission)
+    updown, downdown = correct_for_polarizing_element(up.down, down.down, transmission)
+    return PolarizationCorrectedData(
+        upup=upup, updown=updown, downup=downup, downdown=downdown
+    )
+
+
+def CorrectionWorkflow() -> sciline.Pipeline:
+    return sciline.Pipeline((correct_for_analyzer, correct_for_polarizer))

--- a/src/ess/polarization/correction.py
+++ b/src/ess/polarization/correction.py
@@ -22,8 +22,28 @@ def compute_polarizing_element_correction(
     transmission: TransmissionFunction[PolarizingElement],
 ) -> PolarizingElementCorrection[PolarizerSpin, AnalyzerSpin, PolarizingElement]:
     """
-    denom = Tplus**2 - Tminus**2
-    mat = [[Tplus, -Tminus], [-Tminus, Tplus]]
+    Compute matrix coefficients for the correction of a polarizing element.
+
+    The coefficients stem from the inverse of a symmetric matrix of the form
+    [[Tplus, Tminus], [Tminus, Tplus]]. The inverse is given by a matrix
+        mat = 1/denom * [[Tplus, -Tminus], [-Tminus, Tplus]],
+    with
+        denom = Tplus**2 - Tminus**2.
+    As there are only two unique elements in the matrix, we return them as a dataclass
+    with diagonal and off-diagonal elements.
+
+    Parameters
+    ----------
+    channel :
+        Data including wavelength (and time) for a given spin channel.
+    transmission :
+        Transmission function for the polarizing element.
+
+    Returns
+    -------
+    :
+        Correction matrix coefficients.
+
     """
     t_plus = transmission.apply(channel, 'plus')
     t_minus = transmission.apply(channel, 'minus')
@@ -41,6 +61,23 @@ def compute_polarization_correction(
     analyzer: PolarizingElementCorrection[PolarizerSpin, AnalyzerSpin, Analyzer],
     polarizer: PolarizingElementCorrection[PolarizerSpin, AnalyzerSpin, Polarizer],
 ) -> PolarizationCorrection[PolarizerSpin, AnalyzerSpin]:
+    """
+    Compute combined correction coefficients for polarizer and analyzer.
+
+    This is effectively a column resulting from a sparse matrix-matrix product.
+
+    Parameters
+    ----------
+    analyzer :
+        Correction coefficients for the analyzer.
+    polarizer :
+        Correction coefficients for the polarizer.
+
+    Returns
+    -------
+    :
+        Combined correction coefficients.
+    """
     return PolarizationCorrection[PolarizerSpin, AnalyzerSpin](
         upup=polarizer.diag * analyzer.diag,
         updown=polarizer.diag * analyzer.off_diag,

--- a/src/ess/polarization/correction.py
+++ b/src/ess/polarization/correction.py
@@ -36,6 +36,8 @@ def correct_for_polarizing_element(
     t_minus_up *= up
     t_plus_down *= down
     t_minus_down *= down
+    # TODO Note that this also concatenates all the coordinates, twice. We should share
+    # the coordinates between the two arrays.
     out_up = sc.concat([t_plus_up, t_minus_down], up.dim)
     out_down = sc.concat([t_minus_up, t_plus_down], down.dim)
     return out_up, out_down

--- a/src/ess/polarization/he3.py
+++ b/src/ess/polarization/he3.py
@@ -6,7 +6,8 @@ from typing import Generic, Literal, NewType, TypeVar
 import sciline as sl
 import scipp as sc
 
-from .correction import correct_for_analyzer, correct_for_polarizer
+# from .correction import correct_for_analyzer, correct_for_polarizer
+from .correction import CorrectionWorkflow
 from .types import Analyzer, Polarizer, PolarizingElement, TransmissionFunction
 from .uncertainty import broadcast_with_upper_bound_variances
 
@@ -424,12 +425,12 @@ def He3CellWorkflow(
         get_he3_transmission_from_fit_to_direct_beam,
         direct_beam,
         direct_beam_with_cell,
-        correct_for_analyzer,
-        correct_for_polarizer,
         he3_analyzer,
         he3_polarizer,
     )
-    workflow = sl.Pipeline(providers=steps)
+    workflow = CorrectionWorkflow()
+    for step in steps:
+        workflow.insert(step)
     if in_situ:
         workflow.insert(he3_opacity_function_from_cell_opacity)
     else:

--- a/src/ess/polarization/he3.py
+++ b/src/ess/polarization/he3.py
@@ -400,6 +400,7 @@ def correct_for_he3_cell(
     """
     denom = Tplus**2 - Tminus**2
     mat = [[Tplus, -Tminus], [-Tminus, Tplus]]
+    # TODO Can we make this generic to also handle suppermirror matrices?
     """
     t_plus_up = transmission_function.apply(up, 'plus')
     t_minus_up = -transmission_function.apply(up, 'minus')
@@ -453,6 +454,10 @@ def correct_sample_data_for_polarization(
     #         da = PA_inv[j, i] * channel
     #         da *= weights  # weights from error bars or event counts?
     #         result[j] += da.bins.concat('time', 'wavelength').hist(Qx=100, Qy=100)
+    upup, updown = correct_for_he3_cell(upup, updown, transmission_analyzer)
+    downup, downdown = correct_for_he3_cell(downup, downdown, transmission_analyzer)
+    upup, downup = correct_for_he3_cell(upup, downup, transmission_polarizer)
+    updown, downdown = correct_for_he3_cell(updown, downdown, transmission_polarizer)
     raise NotImplementedError()
 
 

--- a/src/ess/polarization/types.py
+++ b/src/ess/polarization/types.py
@@ -50,3 +50,12 @@ class TransmissionFunction(Generic[PolarizingElement], ABC):
         self, data: sc.DataArray, plus_minus: Literal['plus', 'minus']
     ) -> sc.DataArray:
         ...
+
+
+class PolarizingElementCorrection(
+    Generic[PolarizerSpin, AnalyzerSpin, PolarizingElement]
+):
+    """Correction factors for polarizing element."""
+
+    diag: sc.DataArray
+    off_diag: sc.DataArray

--- a/src/ess/polarization/types.py
+++ b/src/ess/polarization/types.py
@@ -19,24 +19,6 @@ class ReducedSampleDataBySpinChannel(
     """Sample data for a given spin channel."""
 
 
-@dataclass
-class AnalyzerCorrectedData(Generic[PolarizerSpin]):
-    """Sample data with analyzer correction, prior to polarizer correction."""
-
-    analyzer_up: sc.DataArray
-    analyzer_down: sc.DataArray
-
-
-@dataclass
-class PolarizationCorrectedData:
-    """Polarization-corrected sample data."""
-
-    upup: sc.DataArray
-    updown: sc.DataArray
-    downup: sc.DataArray
-    downdown: sc.DataArray
-
-
 Analyzer = NewType('Analyzer', str)
 Polarizer = NewType('Polarizer', str)
 PolarizingElement = TypeVar('PolarizingElement', Analyzer, Polarizer)
@@ -52,10 +34,38 @@ class TransmissionFunction(Generic[PolarizingElement], ABC):
         ...
 
 
+@dataclass
 class PolarizingElementCorrection(
     Generic[PolarizerSpin, AnalyzerSpin, PolarizingElement]
 ):
-    """Correction factors for polarizing element."""
+    """Correction factors for polarizer or analyzer."""
 
     diag: sc.DataArray
     off_diag: sc.DataArray
+
+
+@dataclass
+class PolarizationCorrection(Generic[PolarizerSpin, AnalyzerSpin]):
+    """Combined correction factors for polarizer and analyzer."""
+
+    upup: sc.DataArray
+    updown: sc.DataArray
+    downup: sc.DataArray
+    downdown: sc.DataArray
+
+
+@dataclass
+class PolarizationCorrectedData(Generic[PolarizerSpin, AnalyzerSpin]):
+    """
+    Polarization-corrected sample data.
+
+    The PolarizerSpin and AnalyzerSpin type parameters refer to the measurement. The
+    fields in this class give the resulting data after applying the corrections. For a
+    given measurement with polarizer spin `PolarizerSpin` and analyzer spin
+    `AnalyzerSpin`, there will be resulting intensity in all four output fields.
+    """
+
+    upup: sc.DataArray
+    updown: sc.DataArray
+    downup: sc.DataArray
+    downdown: sc.DataArray

--- a/src/ess/polarization/types.py
+++ b/src/ess/polarization/types.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-from typing import NewType, TypeVar
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Generic, Literal, NewType, TypeVar
 
 import sciline as sl
 import scipp as sc
@@ -11,13 +13,40 @@ PolarizerSpin = TypeVar('PolarizerSpin', Up, Down)
 AnalyzerSpin = TypeVar('AnalyzerSpin', Up, Down)
 
 
-PolarizationCorrectedSampleData = NewType(
-    'PolarizationCorrectedSampleData', sc.DataArray
-)
-"""Polarization-corrected sample data."""
-
-
 class ReducedSampleDataBySpinChannel(
     sl.ScopeTwoParams[PolarizerSpin, AnalyzerSpin, sc.DataArray], sc.DataArray
 ):
     """Sample data for a given spin channel."""
+
+
+@dataclass
+class AnalyzerCorrectedData(Generic[PolarizerSpin]):
+    """Sample data with analyzer correction, prior to polarizer correction."""
+
+    up: sc.DataArray
+    down: sc.DataArray
+
+
+@dataclass
+class PolarizationCorrectedData:
+    """Polarization-corrected sample data."""
+
+    upup: sc.DataArray
+    updown: sc.DataArray
+    downup: sc.DataArray
+    downdown: sc.DataArray
+
+
+Analyzer = NewType('Analyzer', str)
+Polarizer = NewType('Polarizer', str)
+PolarizingElement = TypeVar('PolarizingElement', Analyzer, Polarizer)
+
+
+class TransmissionFunction(Generic[PolarizingElement], ABC):
+    """Wavelength- and time-dependent transmission for a given cell."""
+
+    @abstractmethod
+    def apply(
+        self, data: sc.DataArray, plus_minus: Literal['plus', 'minus']
+    ) -> sc.DataArray:
+        ...

--- a/src/ess/polarization/types.py
+++ b/src/ess/polarization/types.py
@@ -23,8 +23,8 @@ class ReducedSampleDataBySpinChannel(
 class AnalyzerCorrectedData(Generic[PolarizerSpin]):
     """Sample data with analyzer correction, prior to polarizer correction."""
 
-    up: sc.DataArray
-    down: sc.DataArray
+    analyzer_up: sc.DataArray
+    analyzer_down: sc.DataArray
 
 
 @dataclass

--- a/tests/correction_test.py
+++ b/tests/correction_test.py
@@ -63,9 +63,9 @@ class FakeTransmissionFunction:
 
     def apply(self, _: sc.DataArray, plus_minus: str) -> float:
         if plus_minus == 'plus':
-            return float(self.coeffs[0][0])
+            return sc.scalar(self.coeffs[0][0])
         else:
-            return float(self.coeffs[0][1])
+            return sc.scalar(self.coeffs[0][1])
 
 
 def test_correction_workflow_computes_and_applies_matrix_inverse() -> None:
@@ -87,5 +87,9 @@ def test_correction_workflow_computes_and_applies_matrix_inverse() -> None:
     for pol in [Up, Down]:
         for ana in [Up, Down]:
             contrib = workflow.compute(PolarizationCorrectedData[pol, ana])
-            result += [contrib.upup, contrib.updown, contrib.downup, contrib.downdown]
+            contrib = sc.concat(
+                [contrib.upup, contrib.updown, contrib.downup, contrib.downdown],
+                'dummy',
+            )
+            result += contrib.values
     np.testing.assert_allclose(result, ground_truth)

--- a/tests/correction_test.py
+++ b/tests/correction_test.py
@@ -3,7 +3,7 @@
 import scipp as sc
 from scipp.testing import assert_allclose
 
-from ess.polarization import he3
+from ess.polarization.correction import correct_for_polarizing_element
 
 
 class TransmissionFunction:
@@ -30,7 +30,7 @@ def test_correct_for_he3_cell() -> None:
     )
     transmission = TransmissionFunction()
 
-    up, down = he3.correct_for_he3_cell(
+    up, down = correct_for_polarizing_element(
         up=events[:6], down=events[6:], transmission_function=transmission
     )
     assert up.sizes == {'event': 10}

--- a/tests/correction_test.py
+++ b/tests/correction_test.py
@@ -44,3 +44,21 @@ def test_correct_for_analyzer() -> None:
     assert_allclose(up[6:], -events[6:] * transmission_minus[6:] / denom[6:])
     assert_allclose(down[:6], -events[:6] * transmission_minus[:6] / denom[:6])
     assert_allclose(down[6:], events[6:] * transmission_plus[6:] / denom[6:])
+
+
+def test_correction_preserves_coords() -> None:
+    time = sc.linspace('event', 1, 10, 10, unit='')
+    wavelength = sc.linspace('event', 0.1, 1, 10, unit='')
+    events = sc.DataArray(
+        sc.arange('event', 10),
+        coords={'time': time, 'wavelength': wavelength},
+    )
+    events.coords['other'] = sc.linspace('event', 0, 1, 10, unit='')
+    transmission = TransmissionFunction()
+
+    result = correct_for_analyzer(
+        analyzer_up=events[:6], analyzer_down=events[6:], transmission=transmission
+    )
+    for coord in ['time', 'wavelength', 'other']:
+        assert coord in result.analyzer_up.coords
+        assert coord in result.analyzer_down.coords

--- a/tests/correction_test.py
+++ b/tests/correction_test.py
@@ -3,7 +3,7 @@
 import scipp as sc
 from scipp.testing import assert_allclose
 
-from ess.polarization.correction import correct_for_polarizing_element
+from ess.polarization.correction import correct_for_analyzer
 
 
 class TransmissionFunction:
@@ -21,7 +21,7 @@ class TransmissionFunction:
         return self(time, wavelength, plus_minus)
 
 
-def test_correct_for_he3_cell() -> None:
+def test_correct_for_analyzer() -> None:
     time = sc.linspace('event', 1, 10, 10, unit='')
     wavelength = sc.linspace('event', 0.1, 1, 10, unit='')
     events = sc.DataArray(
@@ -30,9 +30,11 @@ def test_correct_for_he3_cell() -> None:
     )
     transmission = TransmissionFunction()
 
-    up, down = correct_for_polarizing_element(
-        up=events[:6], down=events[6:], transmission_function=transmission
+    result = correct_for_analyzer(
+        analyzer_up=events[:6], analyzer_down=events[6:], transmission=transmission
     )
+    up = result.analyzer_up
+    down = result.analyzer_down
     assert up.sizes == {'event': 10}
     assert down.sizes == {'event': 10}
     transmission_plus = transmission(time, wavelength, 'plus')

--- a/tests/correction_test.py
+++ b/tests/correction_test.py
@@ -1,12 +1,25 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+import numpy as np
 import scipp as sc
 from scipp.testing import assert_allclose
 
-from ess.polarization.correction import compute_polarizing_element_correction
+from ess.polarization.correction import (
+    CorrectionWorkflow,
+    compute_polarizing_element_correction,
+)
+from ess.polarization.types import (
+    Analyzer,
+    Down,
+    PolarizationCorrectedData,
+    Polarizer,
+    ReducedSampleDataBySpinChannel,
+    TransmissionFunction,
+    Up,
+)
 
 
-class TransmissionFunction:
+class SimpleTransmissionFunction:
     def __call__(
         self, time: sc.Variable, wavelength: sc.Variable, plus_minus: str
     ) -> sc.Variable:
@@ -28,7 +41,7 @@ def test_compute_polarizing_element_correction() -> None:
         sc.arange('event', 10),
         coords={'time': time, 'wavelength': wavelength},
     )
-    transmission = TransmissionFunction()
+    transmission = SimpleTransmissionFunction()
 
     result = compute_polarizing_element_correction(
         channel=events, transmission=transmission
@@ -42,3 +55,37 @@ def test_compute_polarizing_element_correction() -> None:
     denom = transmission_plus**2 - transmission_minus**2
     assert_allclose(diag, transmission_plus / denom)
     assert_allclose(off_diag, -transmission_minus / denom)
+
+
+class FakeTransmissionFunction:
+    def __init__(self, coeffs: np.ndarray) -> None:
+        self.coeffs = coeffs
+
+    def apply(self, _: sc.DataArray, plus_minus: str) -> float:
+        if plus_minus == 'plus':
+            return float(self.coeffs[0][0])
+        else:
+            return float(self.coeffs[0][1])
+
+
+def test_correction_workflow_computes_and_applies_matrix_inverse() -> None:
+    ground_truth = np.array([7.0, 11.0, 13.0, 17.0])
+    analyzer = np.array([[1.3, 0.9], [0.9, 1.3]])
+    polarizer = np.array([[1.1, 0.7], [0.7, 1.1]])
+    identity = np.array([[1.0, 0.0], [0.0, 1.0]])
+    input = np.kron(identity, analyzer) @ np.kron(polarizer, identity) @ ground_truth
+
+    workflow = CorrectionWorkflow()
+    workflow[TransmissionFunction[Analyzer]] = FakeTransmissionFunction(analyzer)
+    workflow[TransmissionFunction[Polarizer]] = FakeTransmissionFunction(polarizer)
+    workflow[ReducedSampleDataBySpinChannel[Up, Up]] = input[0]
+    workflow[ReducedSampleDataBySpinChannel[Up, Down]] = input[1]
+    workflow[ReducedSampleDataBySpinChannel[Down, Up]] = input[2]
+    workflow[ReducedSampleDataBySpinChannel[Down, Down]] = input[3]
+
+    result = np.zeros(4)
+    for pol in [Up, Down]:
+        for ana in [Up, Down]:
+            contrib = workflow.compute(PolarizationCorrectedData[pol, ana])
+            result += [contrib.upup, contrib.updown, contrib.downup, contrib.downdown]
+    np.testing.assert_allclose(result, ground_truth)


### PR DESCRIPTION
This adds function to apply the inverse of the polarizer and analyzer matrices. I think this should work for both supermirror and He3, I kept this part generic. There are small helper function which serve as glue (connectors) that can be used to, e.g., specify that the `TransmissionFunction[Analyzer]` should use `He3TransmissionFunction[Analyzer]` (which will then result in calling the entire workflow).

Tests are basic, I expect more changes. We will also need to look into performance and memory consumption, there are definitely ways to improve this somewhat.

~Draft for now, since there are more TODOs than anticipated initially.~

Fixes #57.
Fixes #24.