### PR TITLE
Supermirror, flipper matrices, and workflow with configurable polarizer/analyzer

### DIFF
--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -26,8 +26,6 @@
    :recursive:
 
    Analyzer
-   Cell
-   CellInBeamLog
    Depolarized
    DirectBeamBackgroundQRange
    DirectBeamNoCell
@@ -41,13 +39,10 @@
    He3PolarizationFunction
    He3TransmissionFunction
    He3TransmissionEmptyGlass
-   PolarizationCorrectedSampleData
+   PolarizationCorrectedData
    Polarized
    Polarizer
-   RunSectionLog
-   SampleInBeamLog
    Up
-   WavelengthBins
 ```
 
 ## Top-level functions

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -1,5 +1,20 @@
 # API Reference
 
+## Workflows
+
+```{eval-rst}
+.. currentmodule:: ess.polarization
+
+.. autosummary::
+   :toctree: ../generated/classes
+   :template: class-template.rst
+   :recursive:
+
+   CorrectionWorkflow
+   He3CellWorkflow
+   PolarizationAnalysisWorkflow
+   SupermirrorWorkflow
+
 ## Classes
 
 ```{eval-rst}

--- a/docs/user-guide/workflow.ipynb
+++ b/docs/user-guide/workflow.ipynb
@@ -86,7 +86,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workflow = pol.he3.He3CellWorkflow()\n",
+    "he3_workflow = pol.He3CellWorkflow()\n",
+    "workflow = pol.PolarizationAnalysisWorkflow(\n",
+    "    analyzer_workflow=he3_workflow, polarizer_workflow=he3_workflow\n",
+    ")\n",
     "results = (\n",
     "    pol.PolarizationCorrectedData[pol.Up, pol.Up],\n",
     "    pol.PolarizationCorrectedData[pol.Up, pol.Down],\n",
@@ -109,7 +112,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workflow = pol.he3.He3CellWorkflow(in_situ=False)\n",
+    "he3_workflow = pol.he3.He3CellWorkflow(in_situ=False)\n",
+    "workflow = pol.PolarizationAnalysisWorkflow(\n",
+    "    analyzer_workflow=he3_workflow, polarizer_workflow=he3_workflow\n",
+    ")\n",
     "workflow.visualize(results, graph_attr={\"rankdir\": \"LR\"})"
    ]
   },

--- a/docs/user-guide/workflow.ipynb
+++ b/docs/user-guide/workflow.ipynb
@@ -67,7 +67,7 @@
    "source": [
     "workflow = pol.he3.He3CellWorkflow()\n",
     "workflow.visualize(\n",
-    "    pol.He3TransmissionFunction[pol.Polarizer], graph_attr={\"rankdir\": \"LR\"}\n",
+    "    pol.TransmissionFunction[pol.Polarizer], graph_attr={\"rankdir\": \"LR\"}\n",
     ")"
    ]
   },

--- a/src/ess/polarization/__init__.py
+++ b/src/ess/polarization/__init__.py
@@ -12,23 +12,6 @@ except importlib.metadata.PackageNotFoundError:
 del importlib
 
 
-from .base import (
-    CellInBeamLog,
-    CellSpinLog,
-    RunSectionLog,
-    SampleInBeamLog,
-    WavelengthBins,
-    determine_run_section,
-    extract_analyzer_direct_beam_polarized,
-    extract_direct_beam,
-    extract_polarizer_direct_beam_polarized,
-    extract_sample_data_down_down,
-    extract_sample_data_down_up,
-    extract_sample_data_up_down,
-    extract_sample_data_up_up,
-)
-from .base import providers as base_providers
-from .base import run_reduction_workflow
 from .correction import CorrectionWorkflow, PolarizationAnalysisWorkflow
 from .he3 import (
     Depolarized,
@@ -46,14 +29,7 @@ from .he3 import (
     He3TransmissionEmptyGlass,
     He3TransmissionFunction,
     Polarized,
-    direct_beam,
-    direct_beam_with_cell,
-    get_he3_transmission_from_fit_to_direct_beam,
-    he3_opacity_from_cell_params,
-    he3_opacity_function_from_beam_data,
-    he3_opacity_function_from_cell_opacity,
 )
-from .he3 import providers as providers
 from .supermirror import SupermirrorWorkflow
 from .types import (
     Analyzer,
@@ -65,49 +41,29 @@ from .types import (
     Up,
 )
 
-providers = base_providers + providers
-
 __all__ = [
     "Analyzer",
-    "PolarizingElement",
-    "CellInBeamLog",
-    "CellSpinLog",
+    "CorrectionWorkflow",
     "Depolarized",
-    "determine_run_section",
-    "direct_beam",
     "DirectBeamBackgroundQRange",
     "DirectBeamNoCell",
     "DirectBeamQRange",
-    "direct_beam_with_cell",
     "Down",
-    "extract_analyzer_direct_beam_polarized",
-    "extract_direct_beam",
-    "extract_polarizer_direct_beam_polarized",
-    "extract_sample_data_down_down",
-    "extract_sample_data_down_up",
-    "extract_sample_data_up_down",
-    "extract_sample_data_up_up",
-    "get_he3_transmission_from_fit_to_direct_beam",
     "He3CellLength",
     "He3CellPressure",
+    "He3CellWorkflow",
     "He3DirectBeam",
     "He3FillingTime",
     "He3Opacity0",
-    "he3_opacity_from_cell_params",
     "He3OpacityFunction",
-    "he3_opacity_function_from_beam_data",
-    "he3_opacity_function_from_cell_opacity",
     "He3PolarizationFunction",
     "He3TransmissionEmptyGlass",
     "He3TransmissionFunction",
+    "PolarizationAnalysisWorkflow",
     "PolarizationCorrectedData",
-    "Polarized",
     "Polarizer",
-    "providers",
-    "run_reduction_workflow",
+    "PolarizingElement",
     "ReducedSampleDataBySpinChannel",
-    "RunSectionLog",
-    "SampleInBeamLog",
+    "SupermirrorWorkflow",
     "Up",
-    "WavelengthBins",
 ]

--- a/src/ess/polarization/__init__.py
+++ b/src/ess/polarization/__init__.py
@@ -29,6 +29,7 @@ from .base import (
 )
 from .base import providers as base_providers
 from .base import run_reduction_workflow
+from .correction import CorrectionWorkflow, PolarizationAnalysisWorkflow
 from .he3 import (
     Depolarized,
     DirectBeamBackgroundQRange,
@@ -36,6 +37,7 @@ from .he3 import (
     DirectBeamQRange,
     He3CellLength,
     He3CellPressure,
+    He3CellWorkflow,
     He3DirectBeam,
     He3FillingTime,
     He3Opacity0,
@@ -51,7 +53,8 @@ from .he3 import (
     he3_opacity_function_from_beam_data,
     he3_opacity_function_from_cell_opacity,
 )
-from .he3 import providers as he3_providers
+from .he3 import providers as providers
+from .supermirror import SupermirrorWorkflow
 from .types import (
     Analyzer,
     Down,
@@ -62,7 +65,7 @@ from .types import (
     Up,
 )
 
-providers = base_providers + he3_providers
+providers = base_providers + providers
 
 __all__ = [
     "Analyzer",

--- a/src/ess/polarization/__init__.py
+++ b/src/ess/polarization/__init__.py
@@ -38,6 +38,7 @@ from .types import (
     Polarizer,
     PolarizingElement,
     ReducedSampleDataBySpinChannel,
+    TransmissionFunction,
     Up,
 )
 
@@ -65,5 +66,6 @@ __all__ = [
     "PolarizingElement",
     "ReducedSampleDataBySpinChannel",
     "SupermirrorWorkflow",
+    "TransmissionFunction",
     "Up",
 ]

--- a/src/ess/polarization/correction.py
+++ b/src/ess/polarization/correction.py
@@ -54,19 +54,19 @@ class InverseFlipperMatrix(Generic[PolarizerSpin, PolarizingElement]):
             return up + (1 - f) * down, down + (1 - f) * up
 
 
-@dataclass
-class SwapComponent(Generic[PolarizerSpin]):
-    """Helper to implement component swap in flipper matrix"""
-
-    value: bool
-
-
-def make_spin_flipping_matrix(
+def make_spin_flipping_matrix_up(
     efficiency: FlipperEfficiency[PolarizingElement],
-    swap_component: SwapComponent[PolarizerSpin],
-) -> InverseFlipperMatrix[PolarizerSpin, PolarizingElement]:
-    return InverseFlipperMatrix[PolarizerSpin, PolarizingElement](
-        efficiency=efficiency, swap=swap_component.value
+) -> InverseFlipperMatrix[Up, PolarizingElement]:
+    return InverseFlipperMatrix[Up, PolarizingElement](
+        efficiency=efficiency, swap=False
+    )
+
+
+def make_spin_flipping_matrix_down(
+    efficiency: FlipperEfficiency[PolarizingElement],
+) -> InverseFlipperMatrix[Down, PolarizingElement]:
+    return InverseFlipperMatrix[Down, PolarizingElement](
+        efficiency=efficiency, swap=True
     )
 
 
@@ -164,14 +164,13 @@ def compute_polarization_corrected_data(
 def CorrectionWorkflow() -> sciline.Pipeline:
     workflow = sciline.Pipeline(
         (
-            make_spin_flipping_matrix,
+            make_spin_flipping_matrix_up,
+            make_spin_flipping_matrix_down,
             compute_polarizing_element_correction,
             compute_polarization_correction,
             compute_polarization_corrected_data,
         )
     )
-    workflow[SwapComponent[Up]] = SwapComponent[Up](value=False)
-    workflow[SwapComponent[Down]] = SwapComponent[Down](value=True)
     # If there is no flipper, setting an efficiency of 1.0 is equivalent to not using
     # a flipper.
     workflow[FlipperEfficiency[PolarizingElement]] = FlipperEfficiency[

--- a/src/ess/polarization/correction.py
+++ b/src/ess/polarization/correction.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-from typing import Callable, Generic
+from typing import Protocol
 
 import sciline
 import scipp as sc
@@ -47,7 +47,6 @@ def compute_polarizing_element_correction(
     -------
     :
         Correction matrix coefficients.
-
     """
     t_plus = transmission.apply(channel, 'plus')
     t_minus = transmission.apply(channel, 'minus')
@@ -61,35 +60,25 @@ def compute_polarizing_element_correction(
     )
 
 
-class AnalyzerFlipper(Generic[AnalyzerSpin]):
-    """Flipper for the analyzer."""
-
-    def __call__(
-        self, up: sc.Variable, down: sc.Variable
-    ) -> tuple[sc.Variable, sc.Variable]:
-        """Flip the analyzer."""
-        raise NotImplementedError
+Components = tuple[sc.Variable, sc.Variable]
 
 
-class PolarizerFlipper(Generic[PolarizerSpin]):
-    """Flipper for the polarizer."""
-
-    def __call__(
-        self, up: sc.Variable, down: sc.Variable
-    ) -> tuple[sc.Variable, sc.Variable]:
-        """Flip the polarizer."""
-        raise NotImplementedError
+class AnalyzerFlipper(Protocol[AnalyzerSpin]):
+    def __call__(self, up: sc.Variable, down: sc.Variable) -> Components:
+        ...
 
 
-def no_flipper(up: sc.Variable, down: sc.Variable) -> tuple[sc.Variable, sc.Variable]:
+class PolarizerFlipper(Protocol[PolarizerSpin]):
+    def __call__(self, up: sc.Variable, down: sc.Variable) -> Components:
+        ...
+
+
+def no_flipper(up: sc.Variable, down: sc.Variable) -> Components:
     return up, down
 
 
-def flip(up: sc.Variable, down: sc.Variable) -> tuple[sc.Variable, sc.Variable]:
+def flip(up: sc.Variable, down: sc.Variable) -> Components:
     return down, up
-
-
-Flipper = Callable[[sc.Variable, sc.Variable], tuple[sc.Variable, sc.Variable]]
 
 
 def compute_polarization_correction(

--- a/src/ess/polarization/correction.py
+++ b/src/ess/polarization/correction.py
@@ -7,7 +7,7 @@ import networkx as nx
 import sciline
 import scipp as sc
 
-from .he3 import he3_analyzer, he3_polarizer
+from .he3 import He3TransmissionFunction, he3_analyzer, he3_polarizer
 from .supermirror import supermirror_analyzer, supermirror_polarizer
 from .types import (
     Analyzer,
@@ -184,13 +184,8 @@ def CorrectionWorkflow() -> sciline.Pipeline:
 
 
 def _is_he3(workflow: sciline.Pipeline) -> bool:
-    from .he3 import He3TransmissionFunction
-
-    try:
-        workflow.get(He3TransmissionFunction[Polarizer])
-        return True
-    except sciline.UnsatisfiedRequirement:
-        return False
+    # TODO Working around missing __contains__ in sciline.Pipeline
+    return He3TransmissionFunction[Polarizer] in workflow._graph
 
 
 def PolarizationAnalysisWorkflow(

--- a/src/ess/polarization/he3.py
+++ b/src/ess/polarization/he3.py
@@ -256,7 +256,8 @@ def get_he3_transmission_from_fit_to_direct_beam(
     ) -> sc.Variable:
         polarization_function = He3PolarizationFunction[PolarizingElement](C=C, T1=T1)
         if incoming_polarized:
-            # TODO Why is this 'plus'? Does it depend on the supermirror?
+            # TODO Why is this 'plus'? Does it depend on the supermirror and spin
+            # flipper?
             return He3TransmissionFunction(
                 opacity_function=opacity_function,
                 polarization_function=polarization_function,

--- a/src/ess/polarization/he3.py
+++ b/src/ess/polarization/he3.py
@@ -1,14 +1,20 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 from dataclasses import dataclass
-from typing import Generic, Literal, NewType, TypeVar
+from typing import Generic, NewType, TypeVar
 
 import sciline as sl
 import scipp as sc
 
 # from .correction import correct_for_analyzer, correct_for_polarizer
 from .correction import CorrectionWorkflow
-from .types import Analyzer, Polarizer, PolarizingElement, TransmissionFunction
+from .types import (
+    Analyzer,
+    PlusMinus,
+    Polarizer,
+    PolarizingElement,
+    TransmissionFunction,
+)
 from .uncertainty import broadcast_with_upper_bound_variances
 
 Depolarized = NewType('Depolarized', int)
@@ -183,11 +189,7 @@ class He3TransmissionFunction(TransmissionFunction[PolarizingElement]):
     transmission_empty_glass: He3TransmissionEmptyGlass[PolarizingElement]
 
     def __call__(
-        self,
-        *,
-        time: sc.Variable,
-        wavelength: sc.Variable,
-        plus_minus: Literal['plus', 'minus'],
+        self, *, time: sc.Variable, wavelength: sc.Variable, plus_minus: PlusMinus
     ) -> sc.Variable:
         opacity = self.opacity_function(wavelength)
         polarization = self.polarization_function(time)
@@ -195,9 +197,7 @@ class He3TransmissionFunction(TransmissionFunction[PolarizingElement]):
             polarization *= -1.0
         return self.transmission_empty_glass * sc.exp(-opacity * (1.0 + polarization))
 
-    def apply(
-        self, data: sc.DataArray, plus_minus: Literal['plus', 'minus']
-    ) -> sc.DataArray:
+    def apply(self, data: sc.DataArray, plus_minus: PlusMinus) -> sc.DataArray:
         return self(
             time=data.coords['time'],
             wavelength=data.coords['wavelength'],

--- a/src/ess/polarization/he3.py
+++ b/src/ess/polarization/he3.py
@@ -6,13 +6,7 @@ from typing import Generic, NewType, TypeVar
 import sciline as sl
 import scipp as sc
 
-from .types import (
-    Analyzer,
-    PlusMinus,
-    Polarizer,
-    PolarizingElement,
-    TransmissionFunction,
-)
+from .types import PlusMinus, PolarizingElement, TransmissionFunction
 from .uncertainty import broadcast_with_upper_bound_variances
 
 Depolarized = NewType('Depolarized', int)
@@ -238,7 +232,7 @@ def get_he3_transmission_from_fit_to_direct_beam(
     opacity_function: He3OpacityFunction[PolarizingElement],
     transmission_empty_glass: He3TransmissionEmptyGlass[PolarizingElement],
     incoming_polarized: He3CellTransmissionFractionHasPolarizedIncomingBeam,
-) -> He3TransmissionFunction[PolarizingElement]:
+) -> TransmissionFunction[PolarizingElement]:
     """
     Return the transmission function for a given cell.
 
@@ -383,18 +377,6 @@ def direct_beam_with_cell(
     )
 
 
-def he3_analyzer(
-    func: He3TransmissionFunction[Analyzer],
-) -> TransmissionFunction[Analyzer]:
-    return func
-
-
-def he3_polarizer(
-    func: He3TransmissionFunction[Polarizer],
-) -> TransmissionFunction[Polarizer]:
-    return func
-
-
 providers = (
     he3_opacity_from_cell_params,
     get_he3_transmission_from_fit_to_direct_beam,
@@ -419,15 +401,7 @@ def He3CellWorkflow(
         Whether the incoming beam for computing the cell transmission is polarized.
         This is the case in beamlines with a supermirror polarizer.
     """
-    steps = (
-        he3_opacity_from_cell_params,
-        get_he3_transmission_from_fit_to_direct_beam,
-        direct_beam,
-        direct_beam_with_cell,
-        he3_analyzer,
-        he3_polarizer,
-    )
-    workflow = sl.Pipeline(steps)
+    workflow = sl.Pipeline(providers)
     if in_situ:
         workflow.insert(he3_opacity_function_from_cell_opacity)
     else:

--- a/src/ess/polarization/he3.py
+++ b/src/ess/polarization/he3.py
@@ -43,6 +43,7 @@ class He3CellTransmissionFraction(
     """Transmission fraction for a given cell"""
 
 
+# TODO rename and change to Up | Down | Unpolarized
 He3CellTransmissionFractionHasPolarizedIncomingBeam = NewType(
     'He3CellTransmissionFractionHasPolarizedIncomingBeam', bool
 )

--- a/src/ess/polarization/he3.py
+++ b/src/ess/polarization/he3.py
@@ -6,8 +6,6 @@ from typing import Generic, NewType, TypeVar
 import sciline as sl
 import scipp as sc
 
-# from .correction import correct_for_analyzer, correct_for_polarizer
-from .correction import CorrectionWorkflow
 from .types import (
     Analyzer,
     PlusMinus,
@@ -399,7 +397,6 @@ def he3_polarizer(
 
 providers = (
     he3_opacity_from_cell_params,
-    he3_opacity_function_from_beam_data,
     get_he3_transmission_from_fit_to_direct_beam,
     direct_beam,
     direct_beam_with_cell,
@@ -430,9 +427,7 @@ def He3CellWorkflow(
         he3_analyzer,
         he3_polarizer,
     )
-    workflow = CorrectionWorkflow()
-    for step in steps:
-        workflow.insert(step)
+    workflow = sl.Pipeline(steps)
     if in_situ:
         workflow.insert(he3_opacity_function_from_cell_opacity)
     else:

--- a/src/ess/polarization/supermirror.py
+++ b/src/ess/polarization/supermirror.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+
+from dataclasses import dataclass
+from typing import Generic
+
+import scipp as sc
+
+# TODO common name for "cell or supermirror", "Device"?
+from .he3 import Cell
+
+
+@dataclass
+class SupermirrorTransmissionFunction(Generic[Cell]):
+    """Wavelength-dependent transmission of a supermirror"""
+
+    def __call__(self, wavelength: sc.Variable) -> sc.DataArray:
+        """Return the transmission fraction for a given wavelength"""
+        raise NotImplementedError

--- a/src/ess/polarization/supermirror.py
+++ b/src/ess/polarization/supermirror.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Generic
 
+import sciline
 import scipp as sc
 
 from .types import (
@@ -69,9 +70,11 @@ def supermirror_polarizer(
     return func
 
 
-providers = (
+supermirror_providers = (
     get_supermirror_efficiency_function,
     get_supermirror_transmission_function,
-    supermirror_analyzer,
-    supermirror_polarizer,
 )
+
+
+def SupermirrorWorkflow() -> sciline.Pipeline:
+    return sciline.Pipeline(supermirror_providers)

--- a/src/ess/polarization/supermirror.py
+++ b/src/ess/polarization/supermirror.py
@@ -51,7 +51,7 @@ def get_supermirror_efficiency_function() -> (
 
 
 def get_supermirror_transmission_function(
-    efficiency_function: SupermirrorEfficiencyFunction,
+    efficiency_function: SupermirrorEfficiencyFunction[PolarizingElement],
 ) -> SupermirrorTransmissionFunction[PolarizingElement]:
     return SupermirrorTransmissionFunction[PolarizingElement](
         efficiency_function=efficiency_function

--- a/src/ess/polarization/supermirror.py
+++ b/src/ess/polarization/supermirror.py
@@ -2,14 +2,20 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Generic
 
 import scipp as sc
 
-from .types import Analyzer, Polarizer, PolarizingElement, TransmissionFunction
+from .types import (
+    Analyzer,
+    PlusMinus,
+    Polarizer,
+    PolarizingElement,
+    TransmissionFunction,
+)
 
 
-class SupermirrorEfficiencyFunction:
+class SupermirrorEfficiencyFunction(Generic[PolarizingElement]):
     def __call__(self, *, wavelength: sc.Variable) -> sc.DataArray:
         """Return the efficiency of a supermirror for a given wavelength"""
         raise NotImplementedError
@@ -22,10 +28,7 @@ class SupermirrorTransmissionFunction(TransmissionFunction[PolarizingElement]):
     efficiency_function: SupermirrorEfficiencyFunction
 
     def __call__(
-        self,
-        *,
-        wavelength: sc.Variable,
-        plus_minus: Literal['plus', 'minus'],
+        self, *, wavelength: sc.Variable, plus_minus: PlusMinus
     ) -> sc.DataArray:
         """Return the transmission fraction for a given wavelength"""
         efficiency = self.efficiency_function(wavelength=wavelength)
@@ -34,13 +37,24 @@ class SupermirrorTransmissionFunction(TransmissionFunction[PolarizingElement]):
         else:
             return 0.5 * (1 - efficiency)
 
-    def apply(
-        self,
-        data: sc.DataArray,
-        plus_minus: Literal['plus', 'minus'],
-    ) -> sc.DataArray:
+    def apply(self, data: sc.DataArray, plus_minus: PlusMinus) -> sc.DataArray:
         """Apply the transmission function to a data array"""
         return self(wavelength=data.coords['wavelength'], plus_minus=plus_minus)
+
+
+def get_supermirror_efficiency_function() -> (
+    SupermirrorEfficiencyFunction[PolarizingElement]
+):
+    # TODO This will need some input parameters
+    return SupermirrorEfficiencyFunction[PolarizingElement]()
+
+
+def get_supermirror_transmission_function(
+    efficiency_function: SupermirrorEfficiencyFunction,
+) -> SupermirrorTransmissionFunction[PolarizingElement]:
+    return SupermirrorTransmissionFunction[PolarizingElement](
+        efficiency_function=efficiency_function
+    )
 
 
 def supermirror_analyzer(
@@ -53,3 +67,11 @@ def supermirror_polarizer(
     func: SupermirrorTransmissionFunction[Polarizer],
 ) -> TransmissionFunction[Polarizer]:
     return func
+
+
+providers = (
+    get_supermirror_efficiency_function,
+    get_supermirror_transmission_function,
+    supermirror_analyzer,
+    supermirror_polarizer,
+)

--- a/src/ess/polarization/supermirror.py
+++ b/src/ess/polarization/supermirror.py
@@ -7,13 +7,7 @@ from typing import Generic
 import sciline
 import scipp as sc
 
-from .types import (
-    Analyzer,
-    PlusMinus,
-    Polarizer,
-    PolarizingElement,
-    TransmissionFunction,
-)
+from .types import PlusMinus, PolarizingElement, TransmissionFunction
 
 
 class SupermirrorEfficiencyFunction(Generic[PolarizingElement]):
@@ -52,22 +46,10 @@ def get_supermirror_efficiency_function() -> (
 
 def get_supermirror_transmission_function(
     efficiency_function: SupermirrorEfficiencyFunction[PolarizingElement],
-) -> SupermirrorTransmissionFunction[PolarizingElement]:
+) -> TransmissionFunction[PolarizingElement]:
     return SupermirrorTransmissionFunction[PolarizingElement](
         efficiency_function=efficiency_function
     )
-
-
-def supermirror_analyzer(
-    func: SupermirrorTransmissionFunction[Analyzer],
-) -> TransmissionFunction[Analyzer]:
-    return func
-
-
-def supermirror_polarizer(
-    func: SupermirrorTransmissionFunction[Polarizer],
-) -> TransmissionFunction[Polarizer]:
-    return func
 
 
 supermirror_providers = (

--- a/src/ess/polarization/supermirror.py
+++ b/src/ess/polarization/supermirror.py
@@ -2,18 +2,67 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 from dataclasses import dataclass
-from typing import Generic
+from typing import Generic, Literal
 
 import scipp as sc
 
-# TODO common name for "cell or supermirror", "Device"?
-from .he3 import Cell
+from .types import (
+    Analyzer,
+    AnalyzerSpin,
+    Polarizer,
+    PolarizerSpin,
+    PolarizingElement,
+    TransmissionFunction,
+)
+
+
+class SupermirrorEfficiencyFunction:
+    def __call__(self, *, wavelength: sc.Variable) -> sc.DataArray:
+        """Return the efficiency of a supermirror for a given wavelength"""
+        raise NotImplementedError
 
 
 @dataclass
-class SupermirrorTransmissionFunction(Generic[Cell]):
+class SupermirrorTransmissionFunction(TransmissionFunction[PolarizingElement]):
     """Wavelength-dependent transmission of a supermirror"""
 
-    def __call__(self, wavelength: sc.Variable) -> sc.DataArray:
+    efficiency_function: SupermirrorEfficiencyFunction
+
+    def __call__(
+        self,
+        *,
+        wavelength: sc.Variable,
+        plus_minus: Literal['plus', 'minus'],
+    ) -> sc.DataArray:
         """Return the transmission fraction for a given wavelength"""
-        raise NotImplementedError
+        efficiency = self.efficiency_function(wavelength=wavelength)
+        if plus_minus == 'plus':
+            return 0.5 * (1 + efficiency)
+        else:
+            return 0.5 * (1 - efficiency)
+
+
+def supermirror_analyzer(
+    func: SupermirrorTransmissionFunction[Analyzer],
+) -> TransmissionFunction[Analyzer]:
+    return func
+
+
+def supermirror_polarizer(
+    func: SupermirrorTransmissionFunction[Polarizer],
+) -> TransmissionFunction[Polarizer]:
+    return func
+
+
+@dataclass
+class PolarizerSpinFlipper(Generic[PolarizerSpin]):
+    """Also known as F1"""
+
+    value: float
+
+
+@dataclass
+class AnalyzerSpinFlipper(Generic[AnalyzerSpin]):
+    """Also known as F2"""
+
+    value: float

--- a/src/ess/polarization/supermirror.py
+++ b/src/ess/polarization/supermirror.py
@@ -2,18 +2,11 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 from dataclasses import dataclass
-from typing import Generic, Literal
+from typing import Literal
 
 import scipp as sc
 
-from .types import (
-    Analyzer,
-    AnalyzerSpin,
-    Polarizer,
-    PolarizerSpin,
-    PolarizingElement,
-    TransmissionFunction,
-)
+from .types import Analyzer, Polarizer, PolarizingElement, TransmissionFunction
 
 
 class SupermirrorEfficiencyFunction:
@@ -52,17 +45,3 @@ def supermirror_polarizer(
     func: SupermirrorTransmissionFunction[Polarizer],
 ) -> TransmissionFunction[Polarizer]:
     return func
-
-
-@dataclass
-class PolarizerSpinFlipper(Generic[PolarizerSpin]):
-    """Also known as F1"""
-
-    value: float
-
-
-@dataclass
-class AnalyzerSpinFlipper(Generic[AnalyzerSpin]):
-    """Also known as F2"""
-
-    value: float

--- a/src/ess/polarization/supermirror.py
+++ b/src/ess/polarization/supermirror.py
@@ -34,6 +34,14 @@ class SupermirrorTransmissionFunction(TransmissionFunction[PolarizingElement]):
         else:
             return 0.5 * (1 - efficiency)
 
+    def apply(
+        self,
+        data: sc.DataArray,
+        plus_minus: Literal['plus', 'minus'],
+    ) -> sc.DataArray:
+        """Apply the transmission function to a data array"""
+        return self(wavelength=data.coords['wavelength'], plus_minus=plus_minus)
+
 
 def supermirror_analyzer(
     func: SupermirrorTransmissionFunction[Analyzer],

--- a/src/ess/polarization/types.py
+++ b/src/ess/polarization/types.py
@@ -23,14 +23,14 @@ Analyzer = NewType('Analyzer', str)
 Polarizer = NewType('Polarizer', str)
 PolarizingElement = TypeVar('PolarizingElement', Analyzer, Polarizer)
 
+PlusMinus = Literal['plus', 'minus']
+
 
 class TransmissionFunction(Generic[PolarizingElement], ABC):
     """Wavelength- and time-dependent transmission for a given cell."""
 
     @abstractmethod
-    def apply(
-        self, data: sc.DataArray, plus_minus: Literal['plus', 'minus']
-    ) -> sc.DataArray:
+    def apply(self, data: sc.DataArray, plus_minus: PlusMinus) -> sc.DataArray:
         ...
 
 

--- a/src/ess/polarization/types.py
+++ b/src/ess/polarization/types.py
@@ -75,3 +75,10 @@ class PolarizationCorrectedData(Generic[PolarizerSpin, AnalyzerSpin]):
     updown: sc.DataArray
     downup: sc.DataArray
     downdown: sc.DataArray
+
+
+@dataclass
+class FlipperEfficiency(Generic[PolarizingElement]):
+    """Efficiency of a flipper"""
+
+    value: float

--- a/src/ess/polarization/types.py
+++ b/src/ess/polarization/types.py
@@ -43,6 +43,12 @@ class PolarizingElementCorrection(
     diag: sc.DataArray
     off_diag: sc.DataArray
 
+    def get(self, *, up: bool) -> tuple[sc.DataArray, sc.DataArray]:
+        """Get the correction factors for up or down spin."""
+        if up:
+            return self.diag, self.off_diag
+        return self.off_diag, self.diag
+
 
 @dataclass
 class PolarizationCorrection(Generic[PolarizerSpin, AnalyzerSpin]):

--- a/tests/correction_test.py
+++ b/tests/correction_test.py
@@ -2,11 +2,17 @@
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 import numpy as np
 import pytest
+import sciline
 import scipp as sc
 from scipp.testing import assert_allclose
 
-from ess.polarization.correction import (
+from ess.polarization import (
     CorrectionWorkflow,
+    He3CellWorkflow,
+    PolarizationAnalysisWorkflow,
+    SupermirrorWorkflow,
+)
+from ess.polarization.correction import (
     FlipperEfficiency,
     compute_polarizing_element_correction,
 )
@@ -211,3 +217,17 @@ def test_workflow_with_two_flipper_computes_and_applies_matrix_inverse(
             )
             result += contrib.values
     np.testing.assert_allclose(result, ground_truth)
+
+
+_polarizing_element_workflows = [He3CellWorkflow(), SupermirrorWorkflow()]
+
+
+@pytest.mark.parametrize("polarizer_workflow", _polarizing_element_workflows)
+@pytest.mark.parametrize("analyzer_workflow", _polarizing_element_workflows)
+def test_polarization_analysis_workflow_creation(
+    polarizer_workflow: sciline.Pipeline, analyzer_workflow: sciline.Pipeline
+) -> None:
+    _ = PolarizationAnalysisWorkflow(
+        polarizer_workflow=polarizer_workflow, analyzer_workflow=analyzer_workflow
+    )
+    # TODO How to check the workflow graph, without having any of the required inputs?


### PR DESCRIPTION
This adds:

- Flipper matrices (seems to be working, according to tests).
- Supermirror skeleton. The actual efficiency function is not implemented.
- `PolarizationAnalysisWorkflow`, which composes workflows for the polarization and analyzer (each can be He3 or supermirror) into a single workflow.

Fixes #59.
