### PR TITLE
added example of using both he3 and sm in the workflow of the full pipeline

### DIFF
--- a/docs/user-guide/workflow.ipynb
+++ b/docs/user-guide/workflow.ipynb
@@ -67,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workflow = pol.he3.He3CellWorkflow()\n",
+    "workflow = pol.he3.He3CellWorkflow(incoming_polarized=False)\n",
     "workflow.visualize(\n",
     "    pol.TransmissionFunction[pol.Polarizer], graph_attr={\"rankdir\": \"LR\"}\n",
     ")"
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workflow = pol.he3.He3CellWorkflow(in_situ=False, incoming_polarized=True)\n",
+    "workflow = pol.he3.He3CellWorkflow(in_situ=False, incoming_polarized=False)\n",
     "workflow.visualize(\n",
     "    (pol.TransmissionFunction[pol.Polarizer], pol.TransmissionFunction[pol.Analyzer]),\n",
     "    graph_attr={\"rankdir\": \"LR\"},\n",
@@ -138,9 +138,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "he3_workflow = pol.He3CellWorkflow()\n",
+    "he3_polarizer_workflow = pol.He3CellWorkflow(in_situ=True, incoming_polarized=False)\n",
+    "he3_analyzer_workflow = pol.He3CellWorkflow(in_situ=True, incoming_polarized=True)\n",
+    "sm_workflow = pol.supermirror.SupermirrorWorkflow()\n",
+    "\n",
     "workflow = pol.PolarizationAnalysisWorkflow(\n",
-    "    analyzer_workflow=he3_workflow, polarizer_workflow=he3_workflow\n",
+    "    analyzer_workflow=he3_analyzer_workflow, polarizer_workflow=sm_workflow\n",
     ")\n",
     "results = (\n",
     "    pol.PolarizationCorrectedData[pol.Up, pol.Up],\n",
@@ -164,9 +167,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "he3_workflow = pol.he3.He3CellWorkflow(in_situ=False)\n",
+    "he3_polarizer_workflow = pol.He3CellWorkflow(in_situ=False, incoming_polarized=False)\n",
+    "he3_analyzer_workflow = pol.He3CellWorkflow(in_situ=False, incoming_polarized=True)\n",
+    "sm_workflow = pol.supermirror.SupermirrorWorkflow()\n",
+    "\n",
     "workflow = pol.PolarizationAnalysisWorkflow(\n",
-    "    analyzer_workflow=he3_workflow, polarizer_workflow=he3_workflow\n",
+    "    analyzer_workflow=he3_analyzer_workflow, polarizer_workflow=he3_polarizer_workflow\n",
     ")\n",
     "workflow.visualize(results, graph_attr={\"rankdir\": \"LR\"})"
    ]

--- a/docs/user-guide/workflow.ipynb
+++ b/docs/user-guide/workflow.ipynb
@@ -67,7 +67,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workflow = pol.he3.He3CellWorkflow(incoming_polarized=False)\n",
+    "\n",
+    "workflow = pol.he3.He3CellWorkflow(in_situ=True, incoming_polarized=False)\n",
     "workflow.visualize(\n",
     "    pol.TransmissionFunction[pol.Polarizer], graph_attr={\"rankdir\": \"LR\"}\n",
     ")"
@@ -77,7 +78,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There is a variant of the workflow using an incoming polarized beam for computing the transmission function of the analyzer:"
+    "There is a variant of the workflow using an incoming polarized beam for computing the transmission function of the analyzer. \n",
+    "Note that the incoming polarized case only applies to the analyzer, since for the polarizer the incoming neutron beam will always be unpolarized:"
    ]
   },
   {
@@ -86,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workflow = pol.he3.He3CellWorkflow(in_situ=False, incoming_polarized=False)\n",
+    "workflow = pol.he3.He3CellWorkflow(in_situ=True, incoming_polarized=True)\n",
     "workflow.visualize(\n",
     "    (pol.TransmissionFunction[pol.Polarizer], pol.TransmissionFunction[pol.Analyzer]),\n",
     "    graph_attr={\"rankdir\": \"LR\"},\n",
@@ -133,17 +135,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In total, we can choose to use either He3-cells or supermirrors for both the polarizer and analyzer.\n",
+    "Following cell shows an example of using a polarizer supermirror and analyzer He3-cell with an incoming polarized beam and an in-situ opacity calculation:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "he3_polarizer_workflow = pol.He3CellWorkflow(in_situ=True, incoming_polarized=False)\n",
-    "he3_analyzer_workflow = pol.He3CellWorkflow(in_situ=True, incoming_polarized=True)\n",
+    "he3_workflow = pol.He3CellWorkflow(in_situ=True, incoming_polarized=True)\n",
     "sm_workflow = pol.supermirror.SupermirrorWorkflow()\n",
     "\n",
     "workflow = pol.PolarizationAnalysisWorkflow(\n",
-    "    analyzer_workflow=he3_analyzer_workflow, polarizer_workflow=sm_workflow\n",
+    "    analyzer_workflow=he3_workflow, polarizer_workflow=sm_workflow\n",
     ")\n",
     "results = (\n",
     "    pol.PolarizationCorrectedData[pol.Up, pol.Up],\n",
@@ -162,6 +171,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, an example is presented using the opacity calculation from direct-beam measurements (ex-situ case) for having 2x He3-cells as analyzer and polarizer. Note that the incoming-polarized beam only applies to the analyzer, since the polarizer will always use an incoming-unpolarized beam. Hence, one could alternatively use the same command is described under [Transmission function](#Transmission-function) for 2x He3-cells.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -169,7 +185,6 @@
    "source": [
     "he3_polarizer_workflow = pol.He3CellWorkflow(in_situ=False, incoming_polarized=False)\n",
     "he3_analyzer_workflow = pol.He3CellWorkflow(in_situ=False, incoming_polarized=True)\n",
-    "sm_workflow = pol.supermirror.SupermirrorWorkflow()\n",
     "\n",
     "workflow = pol.PolarizationAnalysisWorkflow(\n",
     "    analyzer_workflow=he3_analyzer_workflow, polarizer_workflow=he3_polarizer_workflow\n",
@@ -245,7 +260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the workflow.ipynb under header "Full pipeline" I have added an example for the code to insert both the he3 and sm workflows for different polarizer/analyzer for clarity