### PR TITLE
Add lock around Mantid loading for 5x speedup

### DIFF
--- a/docs/user-guide/zoom.ipynb
+++ b/docs/user-guide/zoom.ipynb
@@ -13,6 +13,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2923794c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.config\n",
+    "\n",
+    "# Loading many small files with Mantid is, for some reason, very slow when using\n",
+    "# the default number of threads. 2 threads is also ok, but 1 is fastest.\n",
+    "dask.config.set(scheduler='threads', num_workers=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "319162e9",
    "metadata": {},
    "outputs": [],

--- a/docs/user-guide/zoom.ipynb
+++ b/docs/user-guide/zoom.ipynb
@@ -13,20 +13,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2923794c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import dask.config\n",
-    "\n",
-    "# Loading many small files with Mantid is, for some reason, very slow when using\n",
-    "# the default number of threads. 2 threads is also ok, but 1 is fastest.\n",
-    "dask.config.set(scheduler='threads', num_workers=1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "319162e9",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
See explanation in comment. I don't really know the reason for this. Setting Mantid's thread count to 1 had no effect, so I would suspect it has something to do with some file locks.

On my workstation computing the transmission fractions now takes 13 seconds instead of 90 seconds.